### PR TITLE
Make automatic scaling to 256 range optional.

### DIFF
--- a/src/test/java/no/ecc/vectortile/VectorTileDecoderTest.java
+++ b/src/test/java/no/ecc/vectortile/VectorTileDecoderTest.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -46,6 +47,23 @@ public class VectorTileDecoderTest extends TestCase {
         assertEquals(-1, VectorTileDecoder.zigZagDecode(1));
         assertEquals(1, VectorTileDecoder.zigZagDecode(2));
         assertEquals(-2, VectorTileDecoder.zigZagDecode(3));
+    }
+    
+    public void testWithoutScaling() throws IOException {
+        Coordinate c = new Coordinate(2, 3);
+        Geometry geometry = gf.createPoint(c);
+        
+        Coordinate c2 = new Coordinate(4, 6);
+        Geometry geometry2 = gf.createPoint(c2);
+        
+        VectorTileEncoder e = new VectorTileEncoder(512);
+        e.addFeature("layer", Collections.EMPTY_MAP, geometry);
+        byte[] encoded = e.encode();
+
+        VectorTileDecoder d = new VectorTileDecoder();
+        d.setAutoScale(false);
+
+        assertEquals(geometry2, d.decode(encoded, "layer").iterator().next().getGeometry());
     }
 
     public void testPoint() throws IOException {

--- a/src/test/java/no/ecc/vectortile/VectorTileEncoderTest.java
+++ b/src/test/java/no/ecc/vectortile/VectorTileEncoderTest.java
@@ -129,6 +129,34 @@ public class VectorTileEncoderTest extends TestCase {
         assertEquals(3, commands.size());
 
     }
+    
+    public void testExtentWithScale() {
+
+        List<Coordinate> cs = new ArrayList<Coordinate>();
+        cs.add(new Coordinate(3, 6));
+        
+        List<Integer> commands = new VectorTileEncoder(512).commands(cs.toArray(new Coordinate[cs.size()]), false);
+        assertNotNull(commands);
+
+        assertCommand(9, commands, 0);
+        assertCommand(12, commands, 1);
+        assertCommand(24, commands, 2);
+        assertEquals(3, commands.size());
+    }
+    
+    public void testExtentWithoutScale() {
+
+        List<Coordinate> cs = new ArrayList<Coordinate>();
+        cs.add(new Coordinate(6, 300));
+        
+        List<Integer> commands = new VectorTileEncoder(512, 8, false).commands(cs.toArray(new Coordinate[cs.size()]), false);
+        assertNotNull(commands);
+
+        assertCommand(9, commands, 0);
+        assertCommand(12, commands, 1);
+        assertCommand(600, commands, 2);
+        assertEquals(3, commands.size());
+    }
 
     public void testFourEqualPoints() {
 


### PR DESCRIPTION
Please consider this change.
It allows to provide coordinates in the 0..extent-1 range immediately, rather than expecting a 0..255 range and scaling.
However, this is just an optional setting and the default behaviour remains the same.