### PR TITLE
Add support for encoding/decoding feature ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ encoder.addFeature("road", attributes, geometry);
 byte[] encoded = encoder.encode();
 ```
 
+or, specifying the feature id:
+
+```java
+VectorTileEncoder encoder = new VectorTileEncoder();
+encoder.addFeature("road", attributes, geometry, id);
+byte[] encoded = encoder.encode();
+```
+
 ## Maven
 
 ```

--- a/src/main/java/no/ecc/vectortile/VectorTileDecoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileDecoder.java
@@ -332,7 +332,7 @@ public class VectorTileDecoder {
                 geometry = gf.createGeometryCollection(new Geometry[0]);
             }
 
-            return new Feature(layerName, extent, geometry, Collections.unmodifiableMap(attributes));
+            return new Feature(layerName, extent, geometry, Collections.unmodifiableMap(attributes), feature.getId());
         }
 
         public void remove() {
@@ -345,18 +345,24 @@ public class VectorTileDecoder {
 
         private final String layerName;
         private final int extent;
+        private final long id;
         private final Geometry geometry;
         private final Map<String, Object> attributes;
 
-        public Feature(String layerName, int extent, Geometry geometry, Map<String, Object> attributes) {
+        public Feature(String layerName, int extent, Geometry geometry, Map<String, Object> attributes, long id) {
             this.layerName = layerName;
             this.extent = extent;
             this.geometry = geometry;
             this.attributes = attributes;
+            this.id = id;
         }
 
         public String getLayerName() {
             return layerName;
+        }
+
+        public long getId() {
+            return id;
         }
 
         public int getExtent() {

--- a/src/test/java/no/ecc/vectortile/VectorTileEncoderTest.java
+++ b/src/test/java/no/ecc/vectortile/VectorTileEncoderTest.java
@@ -20,11 +20,13 @@ package no.ecc.vectortile;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import junit.framework.TestCase;
+import no.ecc.vectortile.VectorTileDecoder.Feature;
 import vector_tile.VectorTile;
 
 import org.locationtech.jts.algorithm.CGAlgorithms;
@@ -323,4 +325,82 @@ public class VectorTileEncoderTest extends TestCase {
         assertEquals("value6", decodedAttributes.get("key6"));
     }
 
+    public void testProvidedIds() throws IOException {
+        VectorTileEncoder vtm = new VectorTileEncoder(256);
+
+        Geometry geometry = gf.createPoint(new Coordinate(3, 6));
+        Map<String, String> attributes = Collections.singletonMap("key1", "value1");
+        vtm.addFeature("DEPCNT", attributes, geometry, 50);
+
+        List<Feature> features = encodeDecodeFeatures(vtm);
+        assertEquals(1, features.size());
+        assertEquals(50, features.get(0).getId());
+    }
+
+    public void testAutoincrementIds() throws IOException {
+        VectorTileEncoder vtm = new VectorTileEncoder(256, 8, true, true);
+
+        for (int i = 0; i < 10; i++) {
+            Geometry geometry = gf.createPoint(new Coordinate(3 * i, 6 * i));
+            Map<String, String> attributes = Collections.singletonMap("key" + i, "value" + i);
+            vtm.addFeature("DEPCNT", attributes, geometry);
+        }
+
+        List<Feature> features = encodeDecodeFeatures(vtm);
+        for (int i = 0; i < features.size(); i++) {
+            assertEquals(i + 1, features.get(i).getId());
+        }
+    }
+
+    public void testProvidedAndAutoincrementIds() throws IOException {
+        VectorTileEncoder vtm = new VectorTileEncoder(256, 8, true, true);
+
+        Geometry geometry = gf.createPoint(new Coordinate(3, 6));
+        Map<String, String> attributes = Collections.singletonMap("key1", "value1");
+        vtm.addFeature("DEPCNT", attributes, geometry, 50);
+
+        geometry = gf.createPoint(new Coordinate(3, 6));
+        attributes = Collections.singletonMap("key1", "value1");
+        vtm.addFeature("DEPCNT", attributes, geometry);
+
+        geometry = gf.createPoint(new Coordinate(3, 6));
+        attributes = Collections.singletonMap("key1", "value1");
+        vtm.addFeature("DEPCNT", attributes, geometry, 27);
+
+        geometry = gf.createPoint(new Coordinate(3, 6));
+        attributes = Collections.singletonMap("key1", "value1");
+        vtm.addFeature("DEPCNT", attributes, geometry);
+
+        List<Feature> features = encodeDecodeFeatures(vtm);
+        assertEquals(4, features.size());
+        assertEquals(50, features.get(0).getId());
+        assertEquals(51, features.get(1).getId());
+        assertEquals(27, features.get(2).getId());
+        assertEquals(52, features.get(3).getId());
+    }
+
+    public void testNullIds() throws IOException {
+        VectorTileEncoder vtm = new VectorTileEncoder(256);
+
+        Geometry geometry = gf.createPoint(new Coordinate(3, 6));
+        Map<String, String> attributes = Collections.singletonMap("key1", "value1");
+        vtm.addFeature("DEPCNT", attributes, geometry, 50);
+
+        geometry = gf.createPoint(new Coordinate(3, 6));
+        attributes = Collections.singletonMap("key1", "value1");
+        vtm.addFeature("DEPCNT", attributes, geometry);
+
+        List<Feature> features = encodeDecodeFeatures(vtm);
+        assertEquals(2, features.size());
+        assertEquals(50, features.get(0).getId());
+        assertEquals(0, features.get(1).getId());
+    }
+
+    private List<Feature> encodeDecodeFeatures(VectorTileEncoder vtm) throws IOException {
+        byte[] encoded = vtm.encode();
+        assertNotSame(0, encoded.length);
+
+        VectorTileDecoder decoder = new VectorTileDecoder();
+        return decoder.decode(encoded, "DEPCNT").asList();
+    }
 }


### PR DESCRIPTION
[Feature ids](https://github.com/mapbox/vector-tile-spec/blob/master/2.1/vector_tile.proto#L32) were not supported. I added the possibility to specify the feature id either in the `addFeature` method or with an `autoincrement` flag in the encoder constructor and then write those ids in the `encode` method.

I added it as new methods/constructors with disabled functionality by default to ensure backwards compatibility.