### PR TITLE
docs: javadoc cleanup in VectorTileEncoder, add maven task

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,24 @@
       </goals>
      </execution>
     </executions>
-   </plugin>   
-  </plugins>
+   </plugin>
+   <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-javadoc-plugin</artifactId>
+    <version>3.1.1</version>
+    <configuration>
+     <quiet>true</quiet>
+     <source>8</source>
+    </configuration>
+    <executions>
+     <execution>
+      <id>attach-javadocs</id>
+      <goals>
+       <goal>jar</goal>
+      </goals>
+    </execution>
+   </executions>
+  </plugin>
+ </plugins>
 </build>
 </project>

--- a/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
@@ -109,9 +109,9 @@ public class VectorTileEncoder {
      * @param autoincrementIds
      * @param simplificationDistanceTolerance
      *            a positive double representing the distance tolerance to be used
-     *            for non-points before (optional) scaling and encoding. A value <=
-     *            0 will prevent simplifying geometry. 0.1 seem to be a good value
-     *            when autoScale is turned on.
+     *            for non-points before (optional) scaling and encoding. A value
+     *            &lt;=0 will prevent simplifying geometry. 0.1 seems to be a good
+     *            value when {@code autoScale} is turned on.
      */
     public VectorTileEncoder(int extent, int clipBuffer, boolean autoScale, boolean autoincrementIds, double simplificationDistanceTolerance) {
         this.extent = extent;


### PR DESCRIPTION
#32 identified a problem with javadocs not building. I see something probably related - a literal `<` char.

This resolves that (at least for me locally), and adds a maven build task to generate the docs. I also fixed some other minor wording / formatting in the same area since it was open.