### PR TITLE
Fix coordinate instances being reused for closing rings

### DIFF
--- a/src/main/java/no/ecc/vectortile/VectorTileDecoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileDecoder.java
@@ -116,7 +116,7 @@ public class VectorTileDecoder {
 
                 if (command == Command.ClosePath) {
                     if (geomType != VectorTile.Tile.GeomType.POINT && !coords.isEmpty()) {
-                        coords.add(coords.get(0));
+                        coords.add(new Coordinate(coords.get(0)));
                     }
                     length--;
                     continue;

--- a/src/test/java/no/ecc/vectortile/VectorTileDecoderTest.java
+++ b/src/test/java/no/ecc/vectortile/VectorTileDecoderTest.java
@@ -37,6 +37,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 public class VectorTileDecoderTest extends TestCase {
 
@@ -180,7 +181,14 @@ public class VectorTileDecoderTest extends TestCase {
         assertEquals(layerName, d.decode(encoded).getLayerNames().iterator().next());
 
         assertEquals(attributes, d.decode(encoded, layerName).asList().get(0).getAttributes());
-        assertEquals(geometry, d.decode(encoded, layerName).asList().get(0).getGeometry());
+
+        Geometry decodedGeometry = d.decode(encoded, layerName).asList().get(0).getGeometry();
+        assertEquals(geometry, decodedGeometry);
+        
+        LinearRing decodedShell = ((Polygon)decodedGeometry).getExteriorRing();
+        // Shell is closed with different point instances
+        assertTrue(decodedShell.getCoordinateN(0).equals2D(decodedShell.getCoordinateN(decodedShell.getNumPoints() - 1)));
+        assertFalse(decodedShell.getCoordinateN(0) == decodedShell.getCoordinateN(decodedShell.getNumPoints() - 1));
 
     }
 


### PR DESCRIPTION
Fix https://github.com/ElectronicChartCentre/java-vector-tile/issues/36
Create a new Coordinate instance when closing polygon rings