### PR TITLE
Fix coordinate instances being reused for closing rings (for legacy JTS packages branch)

### DIFF
--- a/src/main/java/no/ecc/vectortile/VectorTileDecoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileDecoder.java
@@ -116,7 +116,7 @@ public class VectorTileDecoder {
 
                 if (command == Command.ClosePath) {
                     if (geomType != VectorTile.Tile.GeomType.POINT && !coords.isEmpty()) {
-                        coords.add(coords.get(0));
+                        coords.add(new Coordinate(coords.get(0)));
                     }
                     length--;
                     continue;

--- a/src/test/java/no/ecc/vectortile/VectorTileDecoderTest.java
+++ b/src/test/java/no/ecc/vectortile/VectorTileDecoderTest.java
@@ -34,6 +34,7 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.LineString;
 import com.vividsolutions.jts.geom.LinearRing;
 import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
 
 import junit.framework.TestCase;
 import no.ecc.vectortile.VectorTileDecoder.Feature;
@@ -180,8 +181,14 @@ public class VectorTileDecoderTest extends TestCase {
         assertEquals(layerName, d.decode(encoded).getLayerNames().iterator().next());
 
         assertEquals(attributes, d.decode(encoded, layerName).asList().get(0).getAttributes());
-        assertEquals(geometry, d.decode(encoded, layerName).asList().get(0).getGeometry());
 
+        Geometry decodedGeometry = d.decode(encoded, layerName).asList().get(0).getGeometry();
+        assertEquals(geometry, decodedGeometry);
+
+        LineString decodedShell = ((Polygon)decodedGeometry).getExteriorRing();
+        // Shell is closed with different point instances
+        assertTrue(decodedShell.getCoordinateN(0).equals2D(decodedShell.getCoordinateN(decodedShell.getNumPoints() - 1)));
+        assertFalse(decodedShell.getCoordinateN(0) == decodedShell.getCoordinateN(decodedShell.getNumPoints() - 1));
     }
 
     public void testPolygonWithHole() throws IOException {


### PR DESCRIPTION
Fix #36
Create a new Coordinate instance when closing polygon rings