### PR TITLE
Fix polygon orientation calculations

### DIFF
--- a/src/main/java/no/ecc/vectortile/VectorTileDecoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileDecoder.java
@@ -182,9 +182,6 @@ public class VectorTileDecoder {
                     ccw = thisCcw;
                 }
                 LinearRing ring = gf.createLinearRing(ringCoords);
-                if (ccw) {
-                    ring = ring.reverse();
-                }
                 if (ccw == thisCcw) {
                     if (ringsForCurrentPolygon != null) {
                         polygonRings.add(ringsForCurrentPolygon);

--- a/src/main/java/no/ecc/vectortile/VectorTileDecoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileDecoder.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import org.locationtech.jts.algorithm.Orientation;
+import org.locationtech.jts.algorithm.Area;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -169,23 +169,34 @@ public class VectorTileDecoder {
             break;
         case POLYGON:
             List<List<LinearRing>> polygonRings = new ArrayList<List<LinearRing>>();
-            List<LinearRing> ringsForCurrentPolygon = new ArrayList<LinearRing>();
+            List<LinearRing> ringsForCurrentPolygon = null;
+            Boolean ccw = null;
             for (List<Coordinate> cs : coordsList) {
-                // skip exterior with too few coordinates
-                if (ringsForCurrentPolygon.isEmpty() && cs.size() < 4) {
-                    break;
-                }
-                // skip hole with too few coordinates
-                if (ringsForCurrentPolygon.size() > 0 && cs.size() < 4) {
+                Coordinate[] ringCoords = cs.toArray(new Coordinate[cs.size()]);
+                double area = Area.ofRingSigned(ringCoords);
+                if (area == 0) {
                     continue;
                 }
-                LinearRing ring = gf.createLinearRing(cs.toArray(new Coordinate[cs.size()]));
-                if (Orientation.isCCW(ring.getCoordinates())) {
-                    ringsForCurrentPolygon = new ArrayList<LinearRing>();
-                    polygonRings.add(ringsForCurrentPolygon);
+                boolean thisCcw = area < 0;
+                if (ccw == null) {
+                    ccw = thisCcw;
+                }
+                LinearRing ring = gf.createLinearRing(ringCoords);
+                if (ccw) {
+                    ring = ring.reverse();
+                }
+                if (ccw == thisCcw) {
+                    if (ringsForCurrentPolygon != null) {
+                        polygonRings.add(ringsForCurrentPolygon);
+                    }
+                    ringsForCurrentPolygon = new ArrayList<>();
                 }
                 ringsForCurrentPolygon.add(ring);
             }
+            if (ringsForCurrentPolygon != null) {
+                polygonRings.add(ringsForCurrentPolygon);
+            }
+
             List<Polygon> polygons = new ArrayList<Polygon>();
             for (List<LinearRing> rings : polygonRings) {
                 LinearRing shell = rings.get(0);

--- a/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
@@ -457,14 +457,14 @@ public class VectorTileEncoder {
         // So, the code below will make sure that exterior ring is in counter-clockwise order
         // and interior ring in clockwise order.
         LineString exteriorRing = polygon.getExteriorRing();
-        if (Area.ofRingSigned(exteriorRing.getCoordinates()) < 0) {
+        if (Area.ofRingSigned(exteriorRing.getCoordinates()) > 0) {
             exteriorRing = exteriorRing.reverse();
         }
         commands.addAll(commands(exteriorRing.getCoordinates(), true));
 
         for (int i = 0; i < polygon.getNumInteriorRing(); i++) {
             LineString interiorRing = polygon.getInteriorRingN(i);
-            if (Area.ofRingSigned(interiorRing.getCoordinates()) > 0) {
+            if (Area.ofRingSigned(interiorRing.getCoordinates()) < 0) {
                 interiorRing = interiorRing.reverse();
             }
             commands.addAll(commands(interiorRing.getCoordinates(), true));

--- a/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
@@ -24,7 +24,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.locationtech.jts.algorithm.Orientation;
+import org.locationtech.jts.algorithm.Area;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -457,15 +457,15 @@ public class VectorTileEncoder {
         // So, the code below will make sure that exterior ring is in counter-clockwise order
         // and interior ring in clockwise order.
         LineString exteriorRing = polygon.getExteriorRing();
-        if (!Orientation.isCCW(exteriorRing.getCoordinates())) {
-            exteriorRing = (LineString) exteriorRing.reverse();
+        if (Area.ofRingSigned(exteriorRing.getCoordinates()) < 0) {
+            exteriorRing = exteriorRing.reverse();
         }
         commands.addAll(commands(exteriorRing.getCoordinates(), true));
 
         for (int i = 0; i < polygon.getNumInteriorRing(); i++) {
             LineString interiorRing = polygon.getInteriorRingN(i);
-            if (Orientation.isCCW(interiorRing.getCoordinates())) {
-                interiorRing = (LineString) interiorRing.reverse();
+            if (Area.ofRingSigned(interiorRing.getCoordinates()) > 0) {
+                interiorRing = interiorRing.reverse();
             }
             commands.addAll(commands(interiorRing.getCoordinates(), true));
         }


### PR DESCRIPTION
I noticed some problems when trying to re-encode vector tiles from National Land Survey of Finland: 

https://beta-karttakuva.maanmittauslaitos.fi/vectortiles/v20/#12.26/61.68205/27.28554

Basically this process lost some polygons from the vector tiles:

```
    //kotlin
    val dec = VectorTileDecoder()
    val out = VectorTileEncoder()
    val decode = dec.decode(input)
    for (feature in decode.asList()) {
        out.addFeature(feature.layerName, feature.attributes, feature.geometry)
    }
```

One of the issues was that the library assumes outer polygons to always use CCW orientation for outer ring (otherwise poly gets silently discarded).

I fixed the parsing logic to match classifyRings at:

https://github.com/mapbox/vector-tile-js/blob/master/lib/vectortilefeature.js#L197

The new logic detects orientation of outer ring and then just assumes holes have the opposite orientation.

Another problem was that there are some polygons for which Orientation.isCCW doesn't change even when you reverse the ring, such as this one:
```
new WKTReader().read("LINEARRING (-1 172.5625, -1 257, 24.0625 257, 24.1875 251.875, 24.3125 245.3125, 24.375 243.5625, 29.625 243.6875, 33.9375 243.75, 36.1875 243.5625, 38.875 246.125, 48.25 255.125, 50.375 252.875, 52.8125 255.25, 54.6875 257, 61.5625 257, 62.9375 255.625, 63.6875 254.8125, 58.6875 250.125, 58.6875 250, 63.125 245.375, 64.375 243.5, 66.1875 242.1875, 70 238.25, 71.75 236.375, 75.3125 232.6875, 85.6875 242.4375, 94.9375 232.4375, 105.75 221, 123.9375 201.875, 129.75 195.6875, 131 195.75, 142.25 210.625, 141.9375 211.9375, 137.1875 214.3125, 137.125 214.375, 134 216.0625, 131.8125 217.3125, 130.875 217.9375, 129.9375 218.5, 129.0625 219.0625, 127.25 221.6875, 124.6875 225.25, 124 224.75, 122 227.5625, 118.4375 232.5, 117.8125 232, 116.3125 234.1875, 115.625 235.0625, 112.375 239.625, 111.3125 239.3125, 102 246.8125, 100.375 248.0625, 99.875 248, 99.75 247.875, 91.5625 256.3125, 90.875 257, 75.25 257, 74.25 256.0625, 73.4375 257, 240.0625 257, 240.0625 256.8125, 237.5 256.875, 235.125 257, 234.75 257, 234.5 256.75, 234.625 245.6875, 238.5 245.375, 237.875 237.8125, 238 237.75, 241.75 237.5, 240.75 230, 223.25 230, 221.6875 231.875, 221.5 232.4375, 221.375 233.375, 220.5625 238.125, 213.5625 238.375, 208 242.4375, 203.1875 243.875, 198.125 245.375, 189.0625 248, 183.4375 249.625, 182.3125 250, 181.625 249.6875, 175.375 246.6875, 174.9375 246.375, 170.0625 242.6875, 170.1875 239.9375, 173.875 237.6875, 173 236.25, 168.6875 229.4375, 168.3125 228.875, 165.9375 225.125, 169.75 221.125, 171.8125 218.875, 172.375 218.3125, 172.4375 218.3125, 176.6875 222.4375, 177.3125 222.625, 189 222.375, 194.375 222.3125, 203 222.125, 204.6875 220.75, 195.125 209.375, 197.875 204.1875, 205.625 205.0625, 209.25 205.5, 212.625 206.3125, 214.8125 206.8125, 214.875 206.875, 220.0625 208.125, 220.3125 208.75, 220.9375 208.75, 226.1875 209.25, 232.125 209.6875, 238.0625 210, 244 210.1875, 244.4375 206.1875, 245.25 206.1875, 252.0625 206.3125, 257 206.375, 257 181.5625, 250.125 178, 239.125 177.375, 237.875 177.1875, 232.625 176.3125, 231 176, 226.625 175.25, 226.8125 168.1875, 226.875 164.3125, 227 158.375, 227.3125 158.125, 235.9375 158.8125, 242.3125 159.3125, 242.6875 159.25, 243.25 158.8125, 245.25 154.25, 250.25 154.125, 255.4375 164.25, 257 163.4375, 257 137.5, 250.625 138.25, 242.3125 121.875, 240.625 118.5625, 239.9375 117.5625, 238.875 116.75, 237.6875 116.3125, 236.4375 116.3125, 231.5 116.8125, 227.3125 108.5625, 220.0625 116.1875, 210.75 125.875, 203.625 133.5, 201.875 135.3125, 200.125 138.375, 198.625 138.6875, 194.875 139.375, 192.9375 137.6875, 192.375 137.25, 188.5625 134, 188.5625 133.625, 189.5625 132.5625, 199.25 122.3125, 220.375 100.1875, 211.5625 91.5625, 204.125 84.3125, 204.125 84.25, 210.9375 77.375, 214.5 73.75, 216.8125 75.875, 226.9375 85.375, 227 85.375, 235.25 76.3125, 229.125 70.625, 233.75 65.5625, 235.4375 64.8125, 236.25 64.3125, 237 63.75, 237.75 63.0625, 238.75 61.8125, 239.25 60.875, 239.5625 60.1875, 239.8125 59.3125, 240 58.4375, 240.125 57.5, 240.125 56.5625, 240.0625 55.625, 240 55.5, 224.3125 40.5625, 216.5 43.875, 216.4375 44.125, 215.75 45.8125, 212.125 49.6875, 207.25 54.875, 202.8125 50.625, 200.625 48.625, 198.6875 46.6875, 201.8125 43.4375, 196.4375 40.1875, 185 35.75, 178.5 45.1875, 177.3125 47.5625, 176.0625 49.875, 175.125 51.5, 174.75 52.1875, 173.3125 54.4375, 173.6875 55.9375, 174.5 59.375, 171.75 62.125, 167.75 66.1875, 160.3125 59.9375, 161.6875 58.0625, 163.9375 54.9375, 164.75 53.875, 166.1875 51.8125, 163.625 49.9375, 160.25 47.375, 154 52.125, 151.875 54.25, 147.9375 58.125, 144.0625 57, 142 48.125, 139.125 48.1875, 138.4375 45.25, 132.3125 45.0625, 123.6875 47.0625, 126.375 58.6875, 121.0625 63.5625, 119.125 65.375, 116.6875 64.8125, 115.75 62.625, 114.4375 59.625, 112.25 54.5625, 112.0625 54.25, 110.8125 53.125, 110.5 50.875, 110.375 50.25, 109.375 47.875, 106.25 40.6875, 106.125 40.4375, 104.125 35.6875, 107.75 34, 114.4375 30.875, 120.75 27.9375, 126.75 25.1875, 134.75 21.4375, 139.8125 19.125, 143.125 17.5625, 145.625 13.4375, 136.75 8, 127.3125 2.25, 127.25 -1, 105.875 -1, 107.4375 5.4375, 103.75 8.25, 99.6875 11.375, 98.875 11.1875, 96.1875 6.75, 92.0625 -0.3125, 86 3.3125, 85.6875 3.25, 84.5 1.0625, 83.4375 -1, -1 -1, -1 15.6875, 6.875 8.8125, 6.8125 8.75, 12.1875 2.0625, 17 4.75, 21.25 7.0625, 30.25 12.0625, 33.3125 13.75, 33.1875 15.3125, 32.8125 19.1875, 26.9375 21.125, 25.25 21.6875, 24.5625 22.0625, 20.3125 24.625, 18.6875 22.625, 16.4375 19.75, 15.3125 18.5, 9.875 23.25, 6.375 26.25, 6.875 27, 6.375 29.4375, 7.5 31.25, 7.9375 31.625, 9.9375 33.125, 12.1875 34.125, 14.625 34.5625, 17.125 34.4375, 23.5 33.25, 23.9375 33.1875, 28.3125 32.375, 29.5625 36.0625, 30.625 40.25, 31 42.0625, 40.6875 39.1875, 37.0625 28.1875, 41.9375 26.375, 42 26.375, 47.125 24.6875, 56.1875 21.6875, 58.8125 20.8125, 59.375 21.125, 59.75 22.625, 74.625 24.125, 82.25 24.4375, 84.0625 21.8125, 86.375 21.75, 93.25 30.625, 99.1875 38.3125, 96.75 42.875, 92.3125 42.6875, 87.0625 42.375, 80.6875 42.0625, 80.6875 41.0625, 71.625 41.0625, 54.9375 47.125, 55.125 47.75, 33.8125 55.5625, 34.0625 56.875, 31.625 58.75, 30.75 59.375, 21.875 66.0625, 20.0625 67.4375, 16.6875 70.6875, 12.1875 75.0625, 8.6875 78.375, 14.25 85.5625, 15.875 87.6875, 17.0625 89.75, 24.5625 103.3125, 25.625 102.75, 28.9375 104.8125, 28.75 108.1875, 43.6875 103.875, 49 102.3125, 49.8125 104.0625, 52.875 110.3125, 60.6875 108.6875, 69 107.375, 77.0625 106.0625, 82.625 104.1875, 83.8125 103.75, 85.0625 103.375, 86.375 102.9375, 86.8125 102.75, 101.8125 97.625, 103.25 97.125, 108.8125 95.25, 115.75 92.875, 114.75 84.75, 114.625 83.6875, 117.25 81.875, 117.9375 81.4375, 121 77.375, 121.1875 77.375, 121.3125 78.1875, 122.75 77.875, 124.6875 79.9375, 125.3125 79.3125, 129.375 78.375, 131.0625 80.125, 137.5 86.6875, 137.4375 87.8125, 129.0625 93.875, 129.25 94, 130.125 94.875, 133.9375 98.5, 135 98.625, 140.375 99.4375, 141.0625 102.9375, 141.0625 103.0625, 141.6875 104.9375, 142.125 106.125, 142.3125 106.8125, 142.5 107.75, 142.625 108.1875, 142.8125 109.1875, 143.375 111.75, 143.5 112.25, 143.6875 113.6875, 143.8125 115.4375, 143.8125 116.3125, 143.6875 117.8125, 143.4375 118.5625, 143.3125 119.1875, 142.625 120.5, 142 121.4375, 140.375 123.375, 134.1875 125.4375, 129.9375 118.8125, 127.5625 114.75, 125.5625 110.5, 123.9375 106.125, 122.6875 101.625, 120.3125 103.3125, 108.6875 111.75, 115 128.3125, 114.5625 129.125, 105.9375 131.25, 106.9375 135.5625, 97.375 138, 92.75 139.125, 86.5 140.625, 80.1875 142.1875, 79 142.5, 75 146.3125, 70.25 150.8125, 67.1875 150.0625, 65.75 145.875, 42.375 151.875, 36.375 153.375, 29.0625 155.25, 25.625 156.125, 24.3125 152.8125, 23 153.3125, 21.25 149.5, 18.875 144.4375, 15.1875 136.375, 14.125 134.25, 17.5625 132.5, 7.25 111.6875, 10.875 109.875, 3.5625 95, -1 97.25, -1 160.125, 0.4375 159.4375, 5.0625 166.5625, 5.1875 167.25, 0.5 171.25, -1 172.5625)")

Orientation.isCCW(ring.getCoordinates()) == Orientation.isCCW(ring.reverse().getCoordinates())
```

I changed both encoding and decoding to use Area.ofRingSigned() for orientation detection, which works consistently (reversing the ring reverses sign of the area). Without this change in the encoder, some polygons were missing when rendered with MapLibre GL (presumably due to wrong orientation).

The license of the tiles probably doesn't allow them to be included as a test case unfortunately, so I didn't add a unit test to check that the new logic is any better.. Existing tests do pass though.