### PR TITLE
filter out linestring commands consisting of only one move_to command

### DIFF
--- a/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
@@ -431,7 +431,15 @@ public class VectorTileEncoder {
     List<Integer> commands(MultiLineString mls) {
         List<Integer> commands = new ArrayList<Integer>();
         for (int i = 0; i < mls.getNumGeometries(); i++) {
-            commands.addAll(commands(mls.getGeometryN(i).getCoordinates(), false));
+            final List<Integer> geomCommands =
+                    commands(mls.getGeometryN(i).getCoordinates(), false);
+            if (geomCommands.size() > 3) {
+                // if the geometry consists of all identical points (after Math.round()) commands
+                // returns a single move_to command, which is not valid according to the vector tile
+                // specifications.
+                // (https://github.com/mapbox/vector-tile-spec/tree/master/2.1#4343-linestring-geometry-type)
+                commands.addAll(geomCommands);
+            }
         }
         return commands;
     }


### PR DESCRIPTION
This pull request fixes the commands generated for MultiLineStrings. In certain cases clipping added a line which (after rounding) only contained multiple instances of the same point. This resulted in a single `MOVE_TO` command followed by 0 `LINE_TO` commands, which is not valid according to the [vector tile specifications](https://github.com/mapbox/vector-tile-spec/tree/master/2.1#4343-linestring-geometry-type). Fixes #45 