### PR TITLE
handle geometry collections after clipping

### DIFF
--- a/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
@@ -228,6 +228,15 @@ public class VectorTileEncoder {
             return;
         }
 
+        if (geometry.getClass().equals(GeometryCollection.class)) {
+            for (int i = 0; i < geometry.getNumGeometries(); i++) {
+                Geometry subGeometry = geometry.getGeometryN(i);
+                // keeping the id. any better suggestion?
+                addFeature(layerName, attributes, subGeometry, id);
+            }
+            return;
+        }
+
         Layer layer = layers.get(layerName);
         if (layer == null) {
             layer = new Layer();


### PR DESCRIPTION
Geometry collections are handled by recursively adding the geometries within the collection. Geometry collection handling is done before clipping, however clipping can also result in geometry collections. Therefore it's necessary to check for and handle them again, after clipping.