### PR TITLE
Restore x and y offsets after a skipped command

### DIFF
--- a/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
+++ b/src/main/java/no/ecc/vectortile/VectorTileEncoder.java
@@ -484,6 +484,8 @@ public class VectorTileEncoder {
     List<Integer> commands(MultiLineString mls) {
         List<Integer> commands = new ArrayList<Integer>();
         for (int i = 0; i < mls.getNumGeometries(); i++) {
+            final int oldX = x;
+            final int oldY = y;
             final List<Integer> geomCommands =
                     commands(mls.getGeometryN(i).getCoordinates(), false);
             if (geomCommands.size() > 3) {
@@ -492,6 +494,10 @@ public class VectorTileEncoder {
                 // specifications.
                 // (https://github.com/mapbox/vector-tile-spec/tree/master/2.1#4343-linestring-geometry-type)
                 commands.addAll(geomCommands);
+            } else {
+                // reset x and y to the previous value
+                x = oldX;
+                y = oldY;
             }
         }
         return commands;

--- a/src/test/java/no/ecc/vectortile/VectorTileEncoderTest.java
+++ b/src/test/java/no/ecc/vectortile/VectorTileEncoderTest.java
@@ -568,7 +568,32 @@ public class VectorTileEncoderTest extends TestCase {
         MultiLineString multiLineString2 = (MultiLineString) features.get(0).getGeometry();
         assertEquals(2, multiLineString2.getNumGeometries());
     }
-    
+
+    public void testMultiLineStringWithShortStringInMiddle() throws IOException {
+
+        // create MultiLineString with 3 LineStrings. The middle one is very short and will be skipped in encoding.
+        LineString[] lineStrings = new LineString[3];
+        lineStrings[0] = gf.createLineString(new Coordinate[] {new Coordinate(3, 6), new Coordinate(4, 7)});
+        lineStrings[1] = gf.createLineString(new Coordinate[] {new Coordinate(23, 26), new Coordinate(23.0000000001, 26.0000000001)});
+        lineStrings[2] = gf.createLineString(new Coordinate[] {new Coordinate(13, 16), new Coordinate(14, 17)});
+        MultiLineString multiLineString = gf.createMultiLineString(lineStrings);
+
+        Map<String, String> attributes = Collections.singletonMap("key1", "value1");
+
+        VectorTileEncoder vtm = new VectorTileEncoder(256);
+        vtm.addFeature("mp", attributes, multiLineString);
+
+        byte[] encoded = vtm.encode();
+        assertTrue(encoded.length > 0);
+
+        VectorTileDecoder decoder = new VectorTileDecoder();
+        List<Feature> features = decoder.decode(encoded).asList();
+        assertEquals(1, features.size());
+        MultiLineString multiLineString2 = (MultiLineString) features.get(0).getGeometry();
+        assertEquals(2, multiLineString2.getNumGeometries());
+        assertEquals("MULTILINESTRING ((3 6, 4 7), (13 16, 14 17))", multiLineString2.toString());
+    }
+
     public void testMultiPolygonWithEmptyPart() throws Exception {
         MultiPolygon geometry = (MultiPolygon) new WKTReader().read(
                 "MULTIPOLYGON (EMPTY, ((147.70055136112322 -8, 147.71411675664058 -7.5098459186265245, 147.97677825666688 -6.98433869658038, 148.51137982615182 -6.501849776483141, 149.59129240407856 -5.887781810946763, 151.0198102649083 -5.695958233787678, 152.07291705237367 -4.79331418313086, 152.68462294520214 -4.664681549649686, 153.30446294776266 -4.928310636430979, 153.6732984502305 -6.1305857404368, 153.7226232951622 -8, 147.70055136112322 -8)))");


### PR DESCRIPTION
Otherwise the ignored empty move command has a side-effect of moving the write coordintes to an "unknown" location that decoder doesn't know about.

I noticed this issue when some multilinestrings were shifted on a map by a fixed offset, and other multilinestrings 
had disappeared entirely (probably shifted enough to be outside of the tile).

Bug since v1.3.17 ( https://github.com/ElectronicChartCentre/java-vector-tile/commit/e119cb24c59225e2e43406f10eebfcc1b2c0663f )